### PR TITLE
verificação de email cadastrado, email não cadastrado e senha válida

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'bootsnap', '>= 1.4.2', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry'
+  gem 'pry-nav'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
       mimemagic (>= 0.3.0)
       mini_mime (>= 0.1.3)
     childprocess (3.0.0)
+    coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.5)
     devise (4.7.1)
@@ -145,6 +146,15 @@ GEM
     nokogiri (1.10.5-x86-mingw32)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry (0.12.2-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+      spoon (~> 0.0)
+    pry-nav (0.3.0)
+      pry (>= 0.9.10, < 0.13.0)
     public_suffix (4.0.1)
     puma (4.3.0)
       nio4r (~> 2.0)
@@ -210,6 +220,8 @@ GEM
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    spoon (0.0.6)
+      ffi
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -274,6 +286,8 @@ DEPENDENCIES
   devise
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
+  pry
+  pry-nav
   puma (~> 4.1)
   rails (~> 6.0.1)
   sass-rails (>= 6)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,10 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
   # before_action :
+
+  def inactive_message
+    account_active? ? super : :account_inactive
+  end
   
   def create
     # save post
@@ -22,6 +26,4 @@ class ApplicationController < ActionController::Base
     
     devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:name, :email, :password_confirmation, :password, :current_password, :fullname, :razaosocial, :pf_pj, :cpf, :cnpj, :rua, :cep, :bairro, :cidade, :estado, :numero)}
   end
-  
-  
 end

--- a/app/strategies/unsecure_authenticable_strategy.rb
+++ b/app/strategies/unsecure_authenticable_strategy.rb
@@ -1,0 +1,8 @@
+require 'devise/strategies/database_authenticatable'
+
+class UnsecureAuthenticableStrategy < Devise::Strategies::DatabaseAuthenticatable
+  def authenticate!
+    user = User.find_by(email: authentication_hash[:email])
+    fail!(:email_not_found) if user.nil?
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -20,6 +20,10 @@ Devise.setup do |config|
   # with default "from" parameter.
   config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
 
+  config.warden do |manager|
+    manager.default_strategies(scope: :user).unshift(:unsecure_authentication)
+  end
+
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
 

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -1,0 +1,1 @@
+Warden::Strategies.add(:unsecure_authentication, UnsecureAuthenticableStrategy)

--- a/config/locales/devise.pt-BR.yml
+++ b/config/locales/devise.pt-BR.yml
@@ -12,10 +12,11 @@ pt-BR:
     failure:
       already_authenticated: "Bem Vindo! Você está logado."
       inactive: "Sua conta ainda não foi ativada."
-      invalid: "%{authentication_keys} ou senha inválida."
+      invalid: "Senha inválida."
+      not_found_in_database: "Senha Inválida."
       locked: "Sua conta está bloqueada."
       last_attempt: "Você tem mais uma tentativa antes de sua conta ser bloqueada."
-      not_found_in_database: "%{authentication_keys} ou senha inválida."
+      email_not_found: "%{authentication_keys} não encontrado."
       timeout: "Sua sessão expirou. Por favor, faça login novamente para continuar."
       unauthenticated: "Você precisa entrar ou registrar-se antes de continuar."
       unconfirmed: "Você precisa confirmar seu endereço de email antes de continuar."

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -22,6 +22,7 @@ pt-BR:
               confirmation: deve ser igual a senha.
   errors:
     messages:
+    
       already_confirmed: "já foi confirmado, por favor faça login"
       confirmation_period_expired: "precisava ser confirmada em %{period}, por favor solicite um novo link"
       expired: "expirou, por favor solicite uma nova"


### PR DESCRIPTION
Requisitado pelo PO que no login fosse informado se o email digitado está cadastrado ou não no sistema e que caso o email for o cadastrado, informar se a senha está incorreta.